### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 kids.ansi
 =========================
 
-.. image:: https://pypip.in/v/kids.ansi/badge.png
+.. image:: https://img.shields.io/pypi/v/kids.ansi.svg
     :target: https://pypi.python.org/pypi/kids.ansi
 
 .. image:: https://secure.travis-ci.org/0k/kids.ansi.png?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20kids-ansi))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `kids-ansi`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.